### PR TITLE
Create example: throwing while on ice

### DIFF
--- a/examples/dynamics/throwing_while_standing_on_the_ice.py
+++ b/examples/dynamics/throwing_while_standing_on_the_ice.py
@@ -1,5 +1,5 @@
 from sympy import solve, Symbol, Eq
-from symplyphysics import print_expression, Quantity
+from symplyphysics import print_expression
 from symplyphysics.laws.dynamics import friction_force_from_normal_force as friction_force
 from symplyphysics.laws.dynamics import mechanical_work_from_force_and_move as work_friction
 from symplyphysics.laws.dynamics import kinetic_energy_from_mass_and_velocity as kinetic_energy

--- a/examples/dynamics/throwing_while_standing_on_the_ice.py
+++ b/examples/dynamics/throwing_while_standing_on_the_ice.py
@@ -7,6 +7,7 @@ from symplyphysics.definitions import momentum_is_mass_times_velocity as momentu
 from symplyphysics.laws.conservation import momentum_after_collision_equals_to_momentum_before as momentum_conservation
 from symplyphysics.laws.conservation import mechanical_energy_after_equals_to_mechanical_energy_before as energy_conservation
 from symplyphysics.laws.dynamics import force_reaction_from_force_action as third_newton_law
+from symplyphysics.laws.dynamics import acceleration_from_force as second_newton_law
 
 # Example from https://uchitel.pro/%D0%B7%D0%B0%D0%B4%D0%B0%D1%87%D0%B8-%D0%BD%D0%B0-%D0%B7%D0%B0%D0%BA%D0%BE%D0%BD-%D1%81%D0%BE%D1%85%D1%80%D0%B0%D0%BD%D0%B5%D0%BD%D0%B8%D1%8F-%D0%B8%D0%BC%D0%BF%D1%83%D0%BB%D1%8C%D1%81%D0%B0/
 # A skater with a mass of M = 70 kg, standing on the ice,
@@ -23,6 +24,7 @@ distance = Symbol("distance")
 gravity_acceleration = Symbol("gravity_acceleration")
 
 velocity_of_skater = Symbol("velocity_of_scater")
+gravity_force = Symbol("gravity_force")
 
 momentum_of_skater = momentum.definition.subs({
     momentum.mass: mass_of_skater,
@@ -40,8 +42,14 @@ momentum_conservation_law = momentum_conservation.law.subs({
 
 velocity_of_skater_law = solve(momentum_conservation_law, velocity_of_skater, dict=True)[0][velocity_of_skater]
 
+acceleration_law = second_newton_law.law.subs({
+    second_newton_law.acceleration: gravity_acceleration,
+    second_newton_law.force: gravity_force
+})
+gravity_force_value = solve(acceleration_law, gravity_force, dict=True)[0][gravity_force]
+
 reaction_force_value = third_newton_law.law.subs({
-    third_newton_law.force_action: mass_of_skater * gravity_acceleration
+    third_newton_law.force_action: gravity_force_value
 }).rhs
 
 # We take only the modulus of the reaction force vector,

--- a/examples/dynamics/throwing_while_standing_on_the_ice.py
+++ b/examples/dynamics/throwing_while_standing_on_the_ice.py
@@ -1,0 +1,64 @@
+from sympy import solve, Eq
+from symplyphysics import print_expression, units, Symbol, dimensionless
+
+from symplyphysics.laws.dynamics import friction_force_from_normal_force as friction_force
+from symplyphysics.laws.dynamics import mechanical_work_from_force_and_move as work_friction
+from symplyphysics.laws.dynamics import kinetic_energy_from_mass_and_velocity as kinetic_energy
+from symplyphysics.definitions import momentum_is_mass_times_velocity as impuls
+from symplyphysics.laws.conservation import momentum_after_collision_equals_to_momentum_before as impuls_conservation
+
+# Example from https://uchitel.pro/%D0%B7%D0%B0%D0%B4%D0%B0%D1%87%D0%B8-%D0%BD%D0%B0-%D0%B7%D0%B0%D0%BA%D0%BE%D0%BD-%D1%81%D0%BE%D1%85%D1%80%D0%B0%D0%BD%D0%B5%D0%BD%D0%B8%D1%8F-%D0%B8%D0%BC%D0%BF%D1%83%D0%BB%D1%8C%D1%81%D0%B0/
+# A skater with a mass of M = 70 kg, standing on the ice,
+# throws a puck with a mass of m = 0.3 kg horizontally at a speed of v = 40 m/s.
+# How far s will the skater roll back if the coefficient of friction of the skates
+# on the ice is μ = 0.02?
+
+mass_of_skater = Symbol("mass_of_skater", units.mass)
+mass_of_puck = Symbol("mass_of_puck", units.mass)
+friction_factor = Symbol("friction_factor", dimensionless)
+velocity_of_puck = Symbol("velocity_of_puck", units.velocity)
+distance = Symbol("distance", units.length)
+
+gravity_acceleration = Symbol("gravity_acceleration", units.acceleration)
+
+velocity_of_skater = Symbol("velocity_of_scater", units.velocity)
+
+impuls_of_skater = impuls.definition.subs({
+    impuls.mass: mass_of_skater,
+    impuls.velocity: velocity_of_skater
+}).rhs
+impuls_of_puck = impuls.definition.subs({
+    impuls.mass: mass_of_puck,
+    impuls.velocity: velocity_of_puck
+}).rhs
+
+impuls_conservation_law = impuls_conservation.law.subs({
+    impuls_conservation.momentum(impuls_conservation.time_before): 0,
+    impuls_conservation.momentum(impuls_conservation.time_after): impuls_of_skater - impuls_of_puck
+})
+velocity_of_skater_law = solve(impuls_conservation_law,
+                               velocity_of_skater,
+                               dict=True)[0][velocity_of_skater]
+
+friction_force_law = friction_force.law.subs({
+    friction_force.friction_factor: friction_factor,
+    friction_force.normal_reaction: mass_of_skater * gravity_acceleration
+}).rhs
+work_friction_law = work_friction.law.subs({
+    work_friction.force: friction_force_law,
+    work_friction.distance: distance
+}).rhs
+
+kinetic_energy_law = kinetic_energy.law.subs({
+    kinetic_energy.body_mass: mass_of_skater,
+    kinetic_energy.body_velocity: -velocity_of_skater_law
+}).rhs
+
+conservation_energy = Eq(kinetic_energy_law, work_friction_law)
+print(f"Final equation: {print_expression(conservation_energy)}")
+distance_law = solve(conservation_energy,
+                     distance,
+                     dict=True)[0][distance]
+print(f"Total distance equation: {print_expression(distance_law)}")
+
+

--- a/examples/dynamics/throwing_while_standing_on_the_ice.py
+++ b/examples/dynamics/throwing_while_standing_on_the_ice.py
@@ -6,6 +6,7 @@ from symplyphysics.laws.dynamics import mechanical_work_from_force_and_move as w
 from symplyphysics.laws.dynamics import kinetic_energy_from_mass_and_velocity as kinetic_energy
 from symplyphysics.definitions import momentum_is_mass_times_velocity as impuls
 from symplyphysics.laws.conservation import momentum_after_collision_equals_to_momentum_before as impuls_conservation
+from symplyphysics.laws.conservation import mechanical_energy_after_equals_to_mechanical_energy_before as energy_conservation
 
 # Example from https://uchitel.pro/%D0%B7%D0%B0%D0%B4%D0%B0%D1%87%D0%B8-%D0%BD%D0%B0-%D0%B7%D0%B0%D0%BA%D0%BE%D0%BD-%D1%81%D0%BE%D1%85%D1%80%D0%B0%D0%BD%D0%B5%D0%BD%D0%B8%D1%8F-%D0%B8%D0%BC%D0%BF%D1%83%D0%BB%D1%8C%D1%81%D0%B0/
 # A skater with a mass of M = 70 kg, standing on the ice,
@@ -52,7 +53,10 @@ kinetic_energy_law = kinetic_energy.law.subs({
     kinetic_energy.body_velocity: -velocity_of_skater_law
 }).rhs
 
-conservation_energy = Eq(kinetic_energy_law, work_friction_law)
+conservation_energy = energy_conservation.law.subs({
+    energy_conservation.mechanical_energy(energy_conservation.time_before): 0,
+    energy_conservation.mechanical_energy(energy_conservation.time_after): kinetic_energy_law - work_friction_law,
+})
 print(f"Final equation: {print_expression(conservation_energy)}")
 distance_law = solve(conservation_energy, distance, dict=True)[0][distance]
 print(f"Total distance equation: {print_expression(distance_law)}")

--- a/examples/dynamics/throwing_while_standing_on_the_ice.py
+++ b/examples/dynamics/throwing_while_standing_on_the_ice.py
@@ -33,8 +33,8 @@ momentum_of_puck = momentum.definition.subs({
 }).rhs
 
 momentum_conservation_law = momentum_conservation.law.subs({
-    momentum_conservation.momentum(momentum_conservation.time_before): 0,
-    momentum_conservation.momentum(momentum_conservation.time_after): momentum_of_skater - momentum_of_puck
+    momentum_conservation.momentum(momentum_conservation.time_before): momentum_of_skater,
+    momentum_conservation.momentum(momentum_conservation.time_after): momentum_of_puck
 })
 velocity_of_skater_law = solve(momentum_conservation_law, velocity_of_skater, dict=True)[0][velocity_of_skater]
 

--- a/examples/dynamics/throwing_while_standing_on_the_ice.py
+++ b/examples/dynamics/throwing_while_standing_on_the_ice.py
@@ -34,24 +34,21 @@ momentum_of_puck = momentum.definition.subs({
     momentum.mass: mass_of_puck,
     momentum.velocity: velocity_of_puck
 }).rhs
-
 momentum_conservation_law = momentum_conservation.law.subs({
     momentum_conservation.momentum(momentum_conservation.time_before): momentum_of_skater,
     momentum_conservation.momentum(momentum_conservation.time_after): momentum_of_puck
 })
-
 velocity_of_skater_law = solve(momentum_conservation_law, velocity_of_skater, dict=True)[0][velocity_of_skater]
 
 acceleration_law = second_newton_law.law.subs({
-    second_newton_law.acceleration: gravity_acceleration,
-    second_newton_law.force: gravity_force
+    second_newton_law.mass: mass_of_skater,
+    second_newton_law.force: gravity_force,
+    second_newton_law.acceleration: gravity_acceleration
 })
 gravity_force_value = solve(acceleration_law, gravity_force, dict=True)[0][gravity_force]
-
 reaction_force_value = third_newton_law.law.subs({
     third_newton_law.force_action: gravity_force_value
 }).rhs
-
 # We take only the modulus of the reaction force vector,
 # since we set the direction of the vertical axis coinciding with the direction of this vector
 friction_force_value = friction_force.law.subs({
@@ -63,12 +60,10 @@ work_friction_value = work_friction.law.subs({
     work_friction.force: friction_force_value,
     work_friction.distance: distance
 }).rhs
-
 kinetic_energy_value = kinetic_energy.law.subs({
     kinetic_energy.body_mass: mass_of_skater,
     kinetic_energy.body_velocity: velocity_of_skater_law
 }).rhs
-
 conservation_energy = energy_conservation.law.subs({
     energy_conservation.mechanical_energy(energy_conservation.time_before): kinetic_energy_value,
     energy_conservation.mechanical_energy(energy_conservation.time_after): work_friction_value,
@@ -77,6 +72,7 @@ print(f"Final equation: {print_expression(conservation_energy)}")
 distance_equation = solve(conservation_energy, distance, dict=True)[0][distance]
 answer = Eq(distance, distance_equation)
 print(f"Total distance equation: {print_expression(answer)}")
+
 distance_m = distance_equation.subs({
     gravity_acceleration: 9.8,
     mass_of_skater: 70,

--- a/examples/dynamics/throwing_while_standing_on_the_ice.py
+++ b/examples/dynamics/throwing_while_standing_on_the_ice.py
@@ -36,9 +36,7 @@ impuls_conservation_law = impuls_conservation.law.subs({
     impuls_conservation.momentum(impuls_conservation.time_before): 0,
     impuls_conservation.momentum(impuls_conservation.time_after): impuls_of_skater - impuls_of_puck
 })
-velocity_of_skater_law = solve(impuls_conservation_law,
-                               velocity_of_skater,
-                               dict=True)[0][velocity_of_skater]
+velocity_of_skater_law = solve(impuls_conservation_law, velocity_of_skater, dict=True)[0][velocity_of_skater]
 
 friction_force_law = friction_force.law.subs({
     friction_force.friction_factor: friction_factor,
@@ -56,9 +54,7 @@ kinetic_energy_law = kinetic_energy.law.subs({
 
 conservation_energy = Eq(kinetic_energy_law, work_friction_law)
 print(f"Final equation: {print_expression(conservation_energy)}")
-distance_law = solve(conservation_energy,
-                     distance,
-                     dict=True)[0][distance]
+distance_law = solve(conservation_energy, distance, dict=True)[0][distance]
 print(f"Total distance equation: {print_expression(distance_law)}")
 
 

--- a/examples/dynamics/throwing_while_standing_on_the_ice.py
+++ b/examples/dynamics/throwing_while_standing_on_the_ice.py
@@ -38,17 +38,19 @@ momentum_conservation_law = momentum_conservation.law.subs({
     momentum_conservation.momentum(momentum_conservation.time_after): momentum_of_puck
 })
 
-
 velocity_of_skater_law = solve(momentum_conservation_law, velocity_of_skater, dict=True)[0][velocity_of_skater]
 
 reaction_force_value = third_newton_law.law.subs({
-    third_newton_law.force_action: -mass_of_skater * gravity_acceleration
+    third_newton_law.force_action: mass_of_skater * gravity_acceleration
 }).rhs
 
+# We take only the modulus of the reaction force vector,
+# since we set the direction of the vertical axis coinciding with the direction of this vector
 friction_force_value = friction_force.law.subs({
     friction_force.friction_factor: friction_factor,
-    friction_force.normal_reaction: reaction_force_value
+    friction_force.normal_reaction: abs(reaction_force_value)
 }).rhs
+
 work_friction_value = work_friction.law.subs({
     work_friction.force: friction_force_value,
     work_friction.distance: distance

--- a/examples/dynamics/throwing_while_standing_on_the_ice.py
+++ b/examples/dynamics/throwing_while_standing_on_the_ice.py
@@ -1,6 +1,5 @@
-from sympy import solve, Eq
+from sympy import solve
 from symplyphysics import print_expression, units, Symbol, dimensionless
-
 from symplyphysics.laws.dynamics import friction_force_from_normal_force as friction_force
 from symplyphysics.laws.dynamics import mechanical_work_from_force_and_move as work_friction
 from symplyphysics.laws.dynamics import kinetic_energy_from_mass_and_velocity as kinetic_energy
@@ -60,5 +59,3 @@ conservation_energy = energy_conservation.law.subs({
 print(f"Final equation: {print_expression(conservation_energy)}")
 distance_law = solve(conservation_energy, distance, dict=True)[0][distance]
 print(f"Total distance equation: {print_expression(distance_law)}")
-
-

--- a/examples/dynamics/throwing_while_standing_on_the_ice.py
+++ b/examples/dynamics/throwing_while_standing_on_the_ice.py
@@ -1,11 +1,12 @@
-from sympy import solve, Symbol
-from symplyphysics import print_expression
+from sympy import solve, Symbol, Eq
+from symplyphysics import print_expression, Quantity
 from symplyphysics.laws.dynamics import friction_force_from_normal_force as friction_force
 from symplyphysics.laws.dynamics import mechanical_work_from_force_and_move as work_friction
 from symplyphysics.laws.dynamics import kinetic_energy_from_mass_and_velocity as kinetic_energy
 from symplyphysics.definitions import momentum_is_mass_times_velocity as momentum
 from symplyphysics.laws.conservation import momentum_after_collision_equals_to_momentum_before as momentum_conservation
 from symplyphysics.laws.conservation import mechanical_energy_after_equals_to_mechanical_energy_before as energy_conservation
+from symplyphysics.laws.dynamics import force_reaction_from_force_action as third_newton_law
 
 # Example from https://uchitel.pro/%D0%B7%D0%B0%D0%B4%D0%B0%D1%87%D0%B8-%D0%BD%D0%B0-%D0%B7%D0%B0%D0%BA%D0%BE%D0%BD-%D1%81%D0%BE%D1%85%D1%80%D0%B0%D0%BD%D0%B5%D0%BD%D0%B8%D1%8F-%D0%B8%D0%BC%D0%BF%D1%83%D0%BB%D1%8C%D1%81%D0%B0/
 # A skater with a mass of M = 70 kg, standing on the ice,
@@ -36,11 +37,17 @@ momentum_conservation_law = momentum_conservation.law.subs({
     momentum_conservation.momentum(momentum_conservation.time_before): momentum_of_skater,
     momentum_conservation.momentum(momentum_conservation.time_after): momentum_of_puck
 })
+
+
 velocity_of_skater_law = solve(momentum_conservation_law, velocity_of_skater, dict=True)[0][velocity_of_skater]
+
+reaction_force_value = third_newton_law.law.subs({
+    third_newton_law.force_action: -mass_of_skater * gravity_acceleration
+}).rhs
 
 friction_force_value = friction_force.law.subs({
     friction_force.friction_factor: friction_factor,
-    friction_force.normal_reaction: mass_of_skater * gravity_acceleration
+    friction_force.normal_reaction: reaction_force_value
 }).rhs
 work_friction_value = work_friction.law.subs({
     work_friction.force: friction_force_value,
@@ -57,9 +64,10 @@ conservation_energy = energy_conservation.law.subs({
     energy_conservation.mechanical_energy(energy_conservation.time_after): work_friction_value,
 })
 print(f"Final equation: {print_expression(conservation_energy)}")
-distance_value = solve(conservation_energy, distance, dict=True)[0][distance]
-print(f"Total distance equation: {print_expression(distance_value)}")
-distance_m = distance_value.subs({
+distance_equation = solve(conservation_energy, distance, dict=True)[0][distance]
+answer = Eq(distance, distance_equation)
+print(f"Total distance equation: {print_expression(answer)}")
+distance_m = distance_equation.subs({
     gravity_acceleration: 9.8,
     mass_of_skater: 70,
     mass_of_puck: 0.3,

--- a/examples/dynamics/throwing_while_standing_on_the_ice.py
+++ b/examples/dynamics/throwing_while_standing_on_the_ice.py
@@ -1,10 +1,10 @@
-from sympy import solve
-from symplyphysics import print_expression, units, Symbol, dimensionless
+from sympy import solve, Symbol
+from symplyphysics import print_expression
 from symplyphysics.laws.dynamics import friction_force_from_normal_force as friction_force
 from symplyphysics.laws.dynamics import mechanical_work_from_force_and_move as work_friction
 from symplyphysics.laws.dynamics import kinetic_energy_from_mass_and_velocity as kinetic_energy
-from symplyphysics.definitions import momentum_is_mass_times_velocity as impuls
-from symplyphysics.laws.conservation import momentum_after_collision_equals_to_momentum_before as impuls_conservation
+from symplyphysics.definitions import momentum_is_mass_times_velocity as momentum
+from symplyphysics.laws.conservation import momentum_after_collision_equals_to_momentum_before as momentum_conservation
 from symplyphysics.laws.conservation import mechanical_energy_after_equals_to_mechanical_energy_before as energy_conservation
 
 # Example from https://uchitel.pro/%D0%B7%D0%B0%D0%B4%D0%B0%D1%87%D0%B8-%D0%BD%D0%B0-%D0%B7%D0%B0%D0%BA%D0%BE%D0%BD-%D1%81%D0%BE%D1%85%D1%80%D0%B0%D0%BD%D0%B5%D0%BD%D0%B8%D1%8F-%D0%B8%D0%BC%D0%BF%D1%83%D0%BB%D1%8C%D1%81%D0%B0/
@@ -13,49 +13,57 @@ from symplyphysics.laws.conservation import mechanical_energy_after_equals_to_me
 # How far s will the skater roll back if the coefficient of friction of the skates
 # on the ice is μ = 0.02?
 
-mass_of_skater = Symbol("mass_of_skater", units.mass)
-mass_of_puck = Symbol("mass_of_puck", units.mass)
-friction_factor = Symbol("friction_factor", dimensionless)
-velocity_of_puck = Symbol("velocity_of_puck", units.velocity)
-distance = Symbol("distance", units.length)
+mass_of_skater = Symbol("mass_of_skater")
+mass_of_puck = Symbol("mass_of_puck")
+friction_factor = Symbol("friction_factor")
+velocity_of_puck = Symbol("velocity_of_puck")
+distance = Symbol("distance")
 
-gravity_acceleration = Symbol("gravity_acceleration", units.acceleration)
+gravity_acceleration = Symbol("gravity_acceleration")
 
-velocity_of_skater = Symbol("velocity_of_scater", units.velocity)
+velocity_of_skater = Symbol("velocity_of_scater")
 
-impuls_of_skater = impuls.definition.subs({
-    impuls.mass: mass_of_skater,
-    impuls.velocity: velocity_of_skater
+momentum_of_skater = momentum.definition.subs({
+    momentum.mass: mass_of_skater,
+    momentum.velocity: velocity_of_skater
 }).rhs
-impuls_of_puck = impuls.definition.subs({
-    impuls.mass: mass_of_puck,
-    impuls.velocity: velocity_of_puck
+momentum_of_puck = momentum.definition.subs({
+    momentum.mass: mass_of_puck,
+    momentum.velocity: velocity_of_puck
 }).rhs
 
-impuls_conservation_law = impuls_conservation.law.subs({
-    impuls_conservation.momentum(impuls_conservation.time_before): 0,
-    impuls_conservation.momentum(impuls_conservation.time_after): impuls_of_skater - impuls_of_puck
+momentum_conservation_law = momentum_conservation.law.subs({
+    momentum_conservation.momentum(momentum_conservation.time_before): 0,
+    momentum_conservation.momentum(momentum_conservation.time_after): momentum_of_skater - momentum_of_puck
 })
-velocity_of_skater_law = solve(impuls_conservation_law, velocity_of_skater, dict=True)[0][velocity_of_skater]
+velocity_of_skater_law = solve(momentum_conservation_law, velocity_of_skater, dict=True)[0][velocity_of_skater]
 
-friction_force_law = friction_force.law.subs({
+friction_force_value = friction_force.law.subs({
     friction_force.friction_factor: friction_factor,
     friction_force.normal_reaction: mass_of_skater * gravity_acceleration
 }).rhs
-work_friction_law = work_friction.law.subs({
-    work_friction.force: friction_force_law,
+work_friction_value = work_friction.law.subs({
+    work_friction.force: friction_force_value,
     work_friction.distance: distance
 }).rhs
 
-kinetic_energy_law = kinetic_energy.law.subs({
+kinetic_energy_value = kinetic_energy.law.subs({
     kinetic_energy.body_mass: mass_of_skater,
-    kinetic_energy.body_velocity: -velocity_of_skater_law
+    kinetic_energy.body_velocity: velocity_of_skater_law
 }).rhs
 
 conservation_energy = energy_conservation.law.subs({
-    energy_conservation.mechanical_energy(energy_conservation.time_before): 0,
-    energy_conservation.mechanical_energy(energy_conservation.time_after): kinetic_energy_law - work_friction_law,
+    energy_conservation.mechanical_energy(energy_conservation.time_before): kinetic_energy_value,
+    energy_conservation.mechanical_energy(energy_conservation.time_after): work_friction_value,
 })
 print(f"Final equation: {print_expression(conservation_energy)}")
-distance_law = solve(conservation_energy, distance, dict=True)[0][distance]
-print(f"Total distance equation: {print_expression(distance_law)}")
+distance_value = solve(conservation_energy, distance, dict=True)[0][distance]
+print(f"Total distance equation: {print_expression(distance_value)}")
+distance_m = distance_value.subs({
+    gravity_acceleration: 9.8,
+    mass_of_skater: 70,
+    mass_of_puck: 0.3,
+    friction_factor: 0.02,
+    velocity_of_puck: 40
+})
+print(f"Distance is: {distance_m} m")


### PR DESCRIPTION
# Example

A skater weighing $m_{scater} = 70 kg$, standing on the ice, throws a puck weighing $m = 0.3 kg$ horizontally at a speed $v_{puck} = 40 m/s$. How far will skater roll back if the coefficient of friction of the skates on the ice is equal to $\mu = 0.02$?

# Solution

According to the law of conservation of energy, the work of the friction force is spent on changing the kinetic energy
$$0 = E_k - A_{fr} \ \ \ \ => \ \ \ \ E_k = A_{fr}$$
Or
$$m_{skater} v_{skater}^2/2 = F_{fr} S \ \ \ \ (1)$$
where $m_{skater}$ is the mass of the skater, $v_{skater}$ is the acquired speed of the skater at the time of the throw, $S$ is the movement of the skater after the throw, $F_{fr}$ is the friction force of the ice
$$F_{fr} = \mu N \ \ \ \ (2)$$
where $\mu$ is the coefficient of friction of the ice, $N$ is the reaction of the support

According to Newton's second law, projected onto a vertical axis, the positive direction of which will be perpendicular to the ice surface upwards:
$$N - m_{skater} g = 0$$
The sum of these forces is zero because the skater remains on the ice. Then
$$N = m_{skater} g \ \ \ \ (3)$$

From the law of conservation of momentum, the system was at rest at the initial moment, that is, its momentum was zero, then after the throw, the impulses of the skater and the puck appeared, the velocity vectors of which are oppositely directed.
$$0 = P_{skater} - P_{puck} \ \ \ \ => \ \ \ \ P_{skater} = P_{puck}$$
or
$$m_{skater} v_{skater} = m_{puck} v_{puck} \ \ \ \ => \ \ \ \ v_{skater} = v_{puck} m_{puck} / m_{skater} \ \ \ \ (4)$$

Substituting expressions (2)-(4) into (1).
$$(m_{skater}/2) (v_{puck} m_{puck} / m_{skater})^2 = \mu m_{skater} g S$$
And solution is
$$S = (v_{puck}^2 / (2 \mu g)) (m_{puck} / m_{skater})^2$$