### PR TITLE
Core: equivalent_dims

### DIFF
--- a/symplyphysics/__init__.py
+++ b/symplyphysics/__init__.py
@@ -3,7 +3,7 @@ from sympy.physics.units.systems import SI
 from sympy.physics.units.definitions.dimension_definitions import angle as angle_type
 from .core import errors
 from .core.dimensions import dimensionless
-from .core.symbols.quantities import Quantity, list_of_quantities
+from .core.symbols.quantities import Quantity, list_of_quantities, equivalent_dims
 from .core.convert import convert_to
 from .core.symbols.symbols import Function, Symbol, print_expression
 from .core.symbols.prefixes import prefixes
@@ -28,6 +28,7 @@ __all__ = [
     "prefixes",
     "print_expression",
     "list_of_quantities",
+    "equivalent_dims",
     # convert
     "convert_to",
     # decorators

--- a/symplyphysics/core/symbols/quantities.py
+++ b/symplyphysics/core/symbols/quantities.py
@@ -48,3 +48,14 @@ def scale_factor(quantity_: Quantity | float) -> float:
     if isinstance(quantity_, Quantity):
         return quantity_.scale_factor
     return quantity_
+
+
+def equivalent_dims(
+    left_: Quantity | Dimension, right_: Quantity | Dimension,
+) -> bool:
+    if isinstance(left_, Quantity):
+        left_ = left_.dimension
+    if isinstance(right_, Quantity):
+        right_ = right_.dimension
+    
+    return SI.get_dimension_system().equivalent_dims(left_, right_)

--- a/test/chemistry/potential_energy_models/lennard_jones_potential_test.py
+++ b/test/chemistry/potential_energy_models/lennard_jones_potential_test.py
@@ -4,9 +4,9 @@ from symplyphysics import (
     errors,
     units,
     Quantity,
-    SI,
     convert_to,
     assert_approx,
+    equivalent_dims,
 )
 from symplyphysics.laws.chemistry.potential_energy_models import lennard_jones_potential
 
@@ -26,7 +26,7 @@ def test_args_fixture():
 
 def test_basic_law(test_args):
     result = lennard_jones_potential.calculate_potential(test_args.e, test_args.sigma, test_args.r)
-    assert SI.get_dimension_system().equivalent_dims(result.dimension, units.energy)
+    assert equivalent_dims(result, units.energy)
     result_value = convert_to(result, units.joule).evalf(5)
     assert_approx(result_value, 2.6529e-13)
 

--- a/test/core/symbols/quantities_test.py
+++ b/test/core/symbols/quantities_test.py
@@ -1,7 +1,7 @@
 from pytest import raises
 from sympy import Derivative, cos, pi
 from symplyphysics import (units, Quantity, SI, dimensionless)
-from symplyphysics.core.symbols.quantities import scale_factor
+from symplyphysics.core.symbols.quantities import scale_factor, equivalent_dims
 
 # Test Quantity constructor
 
@@ -134,3 +134,17 @@ def test_scale_factor():
     a_float = 1.0
     assert scale_factor(a_quantity) == 1.0
     assert scale_factor(a_float) == 1.0
+
+
+def test_assert_equivalent_dims():
+    q = Quantity(1.0 * units.meter)
+    dim = units.length
+    assert equivalent_dims(q, q)
+    assert equivalent_dims(q, dim)
+    assert equivalent_dims(q.dimension, dim)
+    assert equivalent_dims(dim, dim)
+
+    qb = Quantity(1.0 * units.second)
+    assert not equivalent_dims(qb, q)
+    assert not equivalent_dims(qb, dim)
+    assert not equivalent_dims(qb.dimension, dim)


### PR DESCRIPTION
This core function is supposed to simplify the boilerplate code in tests and might be helpful in general use too.