### PR TITLE
Law: stress due to tension/compression

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
   "configurations": [
     {
       "name": "Python: Current File",
-      "type": "python",
+      "type": "debugpy",
       "request": "launch",
       "program": "${file}",
       "console": "integratedTerminal",
@@ -18,7 +18,7 @@
     },
     {
       "name": "Python: Debug Tests",
-      "type": "python",
+      "type": "debugpy",
       "request": "launch",
       "program": "${file}",
       "purpose": ["debug-test"],

--- a/symplyphysics/core/symbols/quantities.py
+++ b/symplyphysics/core/symbols/quantities.py
@@ -38,6 +38,12 @@ class Quantity(DimensionSymbol, SymQuantity):  # pylint: disable=too-many-ancest
     def identity(self, *_args: Any) -> Self:
         return self
 
+    def _eval_is_positive(self):
+        return self.scale_factor >= 0
+
+    def _eval_Abs(self):
+        return self if self.scale_factor >= 0 else (-1 * self)
+
 
 def list_of_quantities(input_: Sequence[Expr | float], subs_: dict[Expr,
     Quantity]) -> Sequence[Quantity]:

--- a/symplyphysics/laws/dynamics/deformation/tensile_stress_is_youngs_modulus_times_strain.py
+++ b/symplyphysics/laws/dynamics/deformation/tensile_stress_is_youngs_modulus_times_strain.py
@@ -9,7 +9,7 @@ from symplyphysics import (
 )
 
 # Description
-## When an object is under stress or compression, the stress is related to the strain via the
+## When an object is under tension or compression, the stress is related to the strain via the
 ## Young's modulus.
 
 # Law: sigma = E * |dL|/L

--- a/symplyphysics/laws/dynamics/deformation/tensile_stress_is_youngs_modulus_times_strain.py
+++ b/symplyphysics/laws/dynamics/deformation/tensile_stress_is_youngs_modulus_times_strain.py
@@ -1,0 +1,52 @@
+from sympy import Eq, Abs
+from symplyphysics import (
+    units,
+    Quantity,
+    Symbol,
+    print_expression,
+    validate_input,
+    validate_output,
+)
+
+# Description
+## When an object is under stress or compression, the stress is related to the strain via the
+## Young's modulus.
+
+# Law: sigma = E * |dL|/L
+## sigma - stress
+## E - Young's modulus for the object
+## dL - change in length of object
+## L - initial length of object
+
+# Note
+## |dL|/L is called the tensile/compressive strain of the object
+
+stress = Symbol("stress", units.pressure)
+youngs_modulus = Symbol("youngs_modulus", units.pressure)
+change_in_length = Symbol("change_in_length", units.length)
+initial_length = Symbol("initial_length", units.length)
+
+law = Eq(stress, youngs_modulus * Abs(change_in_length) / initial_length)
+
+
+def print_law() -> str:
+    return print_expression(law)
+
+
+@validate_input(
+    youngs_modulus_=youngs_modulus,
+    change_in_length_=change_in_length,
+    initial_length_=initial_length,
+)
+@validate_output(stress)
+def calculate_tensile_stress(
+    youngs_modulus_: Quantity,
+    change_in_length_: Quantity,
+    initial_length_: Quantity,
+) -> Quantity:
+    result = law.rhs.subs({
+        youngs_modulus: youngs_modulus_,
+        change_in_length: change_in_length_,
+        initial_length: initial_length_,
+    })
+    return Quantity(result)

--- a/test/dynamics/deformation/tensile_stress_is_youngs_modulus_times_strain_test.py
+++ b/test/dynamics/deformation/tensile_stress_is_youngs_modulus_times_strain_test.py
@@ -12,29 +12,29 @@ from symplyphysics.laws.dynamics.deformation import (
 
 # Description
 ## An object is being compressed, its initial length is 1 m, and it became 2 mm shorter.
-## The object's Young's modulus is 10 Pa. The stress on the object amounts to 2e-2 Pa.
+## The object's Young's modulus is 10 Pa. The stress on the object amounts to 0.02 Pa.
 
 
 @fixture(name="test_args")
 def test_args_fixture():
     L = Quantity(1.0 * units.meter)
-    dL = Quantity(-2.0 * units.millimeter)
+    D = Quantity(-2.0 * units.millimeter)
     E = Quantity(10.0 * units.pascal)
-    Args = namedtuple("Args", "L dL E")
-    return Args(L=L, dL=dL, E=E)
+    Args = namedtuple("Args", "L D E")
+    return Args(L=L, D=D, E=E)
 
 
 def test_law(test_args):
-    result = stress_strain_law.calculate_tensile_stress(test_args.E, test_args.dL, test_args.L)
-    assert_equal(result, 2e-2 * units.pascal)
+    result = stress_strain_law.calculate_tensile_stress(test_args.E, test_args.D, test_args.L)
+    assert_equal(result, 0.02 * units.pascal)
 
 
 def test_bad_modulus(test_args):
     Eb = Quantity(1.0 * units.coulomb)
     with raises(errors.UnitsError):
-        stress_strain_law.calculate_tensile_stress(Eb, test_args.dL, test_args.L)
+        stress_strain_law.calculate_tensile_stress(Eb, test_args.D, test_args.L)
     with raises(TypeError):
-        stress_strain_law.calculate_tensile_stress(100, test_args.dL, test_args.L)
+        stress_strain_law.calculate_tensile_stress(100, test_args.D, test_args.L)
 
 
 def test_bad_length(test_args):
@@ -44,6 +44,6 @@ def test_bad_length(test_args):
     with raises(TypeError):
         stress_strain_law.calculate_tensile_stress(test_args.E, 100, test_args.L)
     with raises(errors.UnitsError):
-        stress_strain_law.calculate_tensile_stress(test_args.E, test_args.dL, Lb)
+        stress_strain_law.calculate_tensile_stress(test_args.E, test_args.D, Lb)
     with raises(TypeError):
-        stress_strain_law.calculate_tensile_stress(test_args.E, test_args.dL, 100)
+        stress_strain_law.calculate_tensile_stress(test_args.E, test_args.D, 100)

--- a/test/dynamics/deformation/tensile_stress_is_youngs_modulus_times_strain_test.py
+++ b/test/dynamics/deformation/tensile_stress_is_youngs_modulus_times_strain_test.py
@@ -1,0 +1,49 @@
+from collections import namedtuple
+from pytest import fixture, raises
+from symplyphysics import (
+    assert_equal,
+    errors,
+    units,
+    Quantity,
+)
+from symplyphysics.laws.dynamics.deformation import (
+    tensile_stress_is_youngs_modulus_times_strain as stress_strain_law
+)
+
+# Description
+## An object is being compressed, its initial length is 1 m, and it became 2 mm shorter.
+## The object's Young's modulus is 10 Pa. The stress on the object amounts to 2e-2 Pa.
+
+
+@fixture(name="test_args")
+def test_args_fixture():
+    L = Quantity(1.0 * units.meter)
+    dL = Quantity(-2.0 * units.millimeter)
+    E = Quantity(10.0 * units.pascal)
+    Args = namedtuple("Args", "L dL E")
+    return Args(L=L, dL=dL, E=E)
+
+
+def test_law(test_args):
+    result = stress_strain_law.calculate_tensile_stress(test_args.E, test_args.dL, test_args.L)
+    assert_equal(result, 2e-2 * units.pascal)
+
+
+def test_bad_modulus(test_args):
+    Eb = Quantity(1.0 * units.coulomb)
+    with raises(errors.UnitsError):
+        stress_strain_law.calculate_tensile_stress(Eb, test_args.dL, test_args.L)
+    with raises(TypeError):
+        stress_strain_law.calculate_tensile_stress(100, test_args.dL, test_args.L)
+
+
+def test_bad_length(test_args):
+    Lb = Quantity(1.0 * units.coulomb)
+    with raises(errors.UnitsError):
+        stress_strain_law.calculate_tensile_stress(test_args.E, Lb, test_args.L)
+    with raises(TypeError):
+        stress_strain_law.calculate_tensile_stress(test_args.E, 100, test_args.L)
+    with raises(errors.UnitsError):
+        stress_strain_law.calculate_tensile_stress(test_args.E, test_args.dL, Lb)
+    with raises(TypeError):
+        stress_strain_law.calculate_tensile_stress(test_args.E, test_args.dL, 100)


### PR DESCRIPTION
I'm trying to understand why the test fails though, because the law explicitly uses the absolute value of change in length