### PR TITLE
Fix doc link for effective cross section

### DIFF
--- a/symplyphysics/laws/chemistry/interaction_cross_section_in_coulomb_interaction_model.py
+++ b/symplyphysics/laws/chemistry/interaction_cross_section_in_coulomb_interaction_model.py
@@ -3,7 +3,7 @@ Interaction cross section in Coulomb's interaction model
 ========================================================
 
 In a magnetron, the effective cross section of particle interaction can be calculated via the
-ionization energy of gas atoms. See :ref:`Effective cross section`.
+ionization energy of gas atoms. See :ref:`effective-cross-section`.
 
 **Notation:**
 

--- a/symplyphysics/laws/chemistry/interaction_cross_section_in_elastic_interaction_model.py
+++ b/symplyphysics/laws/chemistry/interaction_cross_section_in_elastic_interaction_model.py
@@ -3,7 +3,7 @@ Interaction cross section in elastic interaction model
 ======================================================
 
 The Sutherland formula adjusts the formula of the cross section of interacting gas molecules
-taking into account their pairwise interactions. See :ref:`Effective cross section`.
+taking into account their pairwise interactions. See :ref:`effective-cross-section`.
 
 **Conditions:**
 

--- a/symplyphysics/laws/chemistry/interaction_cross_section_in_recharge_model.py
+++ b/symplyphysics/laws/chemistry/interaction_cross_section_in_recharge_model.py
@@ -2,7 +2,7 @@
 Interaction cross section in recharge model
 ===========================================
 
-See :ref:`Effective cross section`.
+See :ref:`effective-cross-section`.
 
 **Notation:**
 


### PR DESCRIPTION
## Summary
- fix references to the "Effective cross section" section so Sphinx can find it

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ea488d41c8328ae42e4b3de9e931e