### PR TITLE
Fix minor documentation bugs

### DIFF
--- a/symplyphysics/core/approx.py
+++ b/symplyphysics/core/approx.py
@@ -148,4 +148,5 @@ __all__ = [
     "approx_equal_numbers",
     "approx_equal_quantities",
     "assert_equal",
+    "assert_equal_vectors",
 ]

--- a/symplyphysics/core/experimental/solvers/__init__.py
+++ b/symplyphysics/core/experimental/solvers/__init__.py
@@ -64,8 +64,7 @@ def solve_for_vector(
         expr = expr.lhs - expr.rhs
 
     if not is_vector_expr(expr):
-        # TODO: Raise `ValueError` instead as it is done in other places
-        raise TypeError(f"Expected '{expr}' to be a vector.")
+        raise ValueError(f"Expected '{expr}' to be a vector.")
 
     combination = tuple(split_factor(term) for term in into_terms(expr))
     i = None

--- a/symplyphysics/docs/printer_code.py
+++ b/symplyphysics/docs/printer_code.py
@@ -327,7 +327,7 @@ class SymbolCodePrinter(StrPrinter):  # pylint: disable=too-few-public-methods
             s_lo = self._print(lo)
             s_hi = self._print(hi)
 
-            return f"LineIntegral({s_integrand}, ({s_parameter, s_lo, s_hi}))"
+            return f"LineIntegral({s_integrand}, ({s_parameter}, {s_lo}, {s_hi}))"
 
         s_curve = self._print(curve)
 

--- a/symplyphysics/docs/printer_latex.py
+++ b/symplyphysics/docs/printer_latex.py
@@ -414,7 +414,7 @@ class SymbolLatexPrinter(LatexPrinter):
     # pylint: disable-next=invalid-name
     def _print_VectorLaplacian(self, expr: VectorLaplacian) -> str:
         # NOTE: the argument might need wrapping in parentheses
-        return f"\\nabla^2 {self._print(expr.args[0])})"
+        return f"\\nabla^2 {self._print(expr.args[0])}"
 
     def _print_LineIntegral(self, expr: LineIntegral) -> str:
         integrand, curve, *rest = expr.args

--- a/symplyphysics/quantities/__init__.py
+++ b/symplyphysics/quantities/__init__.py
@@ -292,7 +292,7 @@ vacuum_impedance = Quantity(376.730313412 * units.ohm, display_symbol="Z_0")
 """
 The **impedance of free space** is a physical constant relating the magnitudes of the
 electric and magnetic fields of electromagnetic radiation travelling through free space.
-A common appoximation of its value is :math:`120 \\pi \\, \\Omega`.
+A common approximation of its value is :math:`120 \\pi \\, \\Omega`.
 
 **Links:**
 

--- a/test/core/experimental/solvers/test_solve.py
+++ b/test/core/experimental/solvers/test_solve.py
@@ -66,7 +66,7 @@ def test_express_atomic() -> None:
     assert vector_equals(new_eqn, c - a * 2)
 
     # The expression is not a VectorExpr
-    with raises(TypeError):
+    with raises(ValueError):
         solve_for_vector(norm(a), a)
 
     # The expression does not contain the symbol

--- a/test/dynamics/vector/torque_is_angular_momentum_derivative_test.py
+++ b/test/dynamics/vector/torque_is_angular_momentum_derivative_test.py
@@ -51,9 +51,9 @@ def test_bad_angular_momenta(test_args: Args) -> None:
         torque_law.calculate_torque(test_args.L0, Lb, test_args.t)
 
     Ls = Quantity(1.0 * units.kilogram * units.meter**2 / units.second)
-    with raises(TypeError):
+    with raises(ValueError):
         torque_law.calculate_torque(Ls, test_args.L1, test_args.t)
-    with raises(TypeError):
+    with raises(ValueError):
         torque_law.calculate_torque(test_args.L0, Ls, test_args.t)
 
     with raises(TypeError):


### PR DESCRIPTION
## Summary
- export `assert_equal_vectors`
- correct code printer formatting for `LineIntegral`
- drop extra parenthesis in LaTeX printer
- fix typo in vacuum impedance description
- raise `ValueError` for non-vector input

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68681b0b81608328a550c7e8e376bf86