### PR TITLE
Fix typos in documentation and tests

### DIFF
--- a/symplyphysics/conditions/dynamics/equilibrium/total_torque_is_zero.py
+++ b/symplyphysics/conditions/dynamics/equilibrium/total_torque_is_zero.py
@@ -14,7 +14,7 @@ from symplyphysics import symbols
 
 total_torque = symbols.torque
 """
-Total :symbols:`torque` is the magnitue of the vector sum of all torques acting on the body.
+Total :symbols:`torque` is the magnitude of the vector sum of all torques acting on the body.
 """
 
 law = Eq(total_torque, 0)

--- a/symplyphysics/laws/astronomy/radius_of_planets_orbit_from_its_number.py
+++ b/symplyphysics/laws/astronomy/radius_of_planets_orbit_from_its_number.py
@@ -32,7 +32,7 @@ orbit_radius = symbols.radius
 planet_number = symbols.whole_number
 """
 The value :math:`-\\infty` corresponds to Mercury, :math:`0` to Venus, :math:`1` to
-Earth, :math:`2` to Mars, :math:`3` to Ceres, :math:`4` to Jupyter, :math:`5` to Saturn,
+Earth, :math:`2` to Mars, :math:`3` to Ceres, :math:`4` to Jupiter, :math:`5` to Saturn,
 :math:`6` to Uranus, and :math:`7` to Pluto.
 """
 

--- a/symplyphysics/laws/astronomy/radius_of_planets_orbit_from_its_number.py
+++ b/symplyphysics/laws/astronomy/radius_of_planets_orbit_from_its_number.py
@@ -31,7 +31,7 @@ orbit_radius = symbols.radius
 
 planet_number = symbols.whole_number
 """
-The value :math:`-\\infty` corresponts to Mercury, :math:`0` to Venus, :math:`1` to
+The value :math:`-\\infty` corresponds to Mercury, :math:`0` to Venus, :math:`1` to
 Earth, :math:`2` to Mars, :math:`3` to Ceres, :math:`4` to Jupyter, :math:`5` to Saturn,
 :math:`6` to Uranus, and :math:`7` to Pluto.
 """

--- a/symplyphysics/laws/dynamics/reduced_mass_of_two_body_system.py
+++ b/symplyphysics/laws/dynamics/reduced_mass_of_two_body_system.py
@@ -3,7 +3,7 @@ Reduced mass of a two-body system
 =================================
 
 Reduced mass is effective inertial mass in a system with two or more particles when they
-are interacting with each other. This allowes the two-body problem to be solved as if it
+are interacting with each other. This allows the two-body problem to be solved as if it
 were a one-body problem.
 
 **Links:**

--- a/symplyphysics/laws/electricity/circuits/waveguides/characteristic_resistance_of_rectangular_waveguide_for_transverse_magnetic_waves.py
+++ b/symplyphysics/laws/electricity/circuits/waveguides/characteristic_resistance_of_rectangular_waveguide_for_transverse_magnetic_waves.py
@@ -1,5 +1,5 @@
 """
-Characteristic resitance of rectangular waveguide for transverse magnetic waves
+Characteristic resistance of rectangular waveguide for transverse magnetic waves
 ===============================================================================
 
 The resistance of a rectangular waveguide to transverse magnetic waves can be calculated

--- a/symplyphysics/laws/electricity/circuits/waveguides/characteristic_resistance_of_rectangular_waveguide_for_transverse_magnetic_waves.py
+++ b/symplyphysics/laws/electricity/circuits/waveguides/characteristic_resistance_of_rectangular_waveguide_for_transverse_magnetic_waves.py
@@ -1,6 +1,6 @@
 """
 Characteristic resistance of rectangular waveguide for transverse magnetic waves
-===============================================================================
+================================================================================
 
 The resistance of a rectangular waveguide to transverse magnetic waves can be calculated
 from the resistance of the medium within the waveguide, the wavelength of the signal

--- a/symplyphysics/laws/kinematics/vector/coriolis_acceleration.py
+++ b/symplyphysics/laws/kinematics/vector/coriolis_acceleration.py
@@ -32,7 +32,7 @@ coriolis_acceleration = clone_as_vector_symbol(
     display_latex="{\\vec a}_\\text{Cor}",
 )
 """
-Vector of the body's Coreolis :symbols:`acceleration` in :math:`S'`.
+Vector of the body's Coriolis :symbols:`acceleration` in :math:`S'`.
 """
 
 relative_velocity = clone_as_vector_symbol(

--- a/symplyphysics/laws/quantum_mechanics/schrodinger/free_particle_plane_wave_solution.py
+++ b/symplyphysics/laws/quantum_mechanics/schrodinger/free_particle_plane_wave_solution.py
@@ -14,7 +14,7 @@ a `plane wave <https://en.wikipedia.org/wiki/Plane_wave>`__.
 #. The energy and momentum of a quantum particle are related by the equation :math:`E = p^2 / (2 m)`
    where :math:`m` is the mass of the quantum particle.
 #. The wave function must be normalized, i.e. the integral of the square of its absolute value
-   over the whole range of the spatial variable must equal 1, but the integral of the complex expontential
+   over the whole range of the spatial variable must equal 1, but the integral of the complex exponential
    diverges if taken over the real line. This is not a problem, though, because the states described by
    such a wave function would never be infinite (they would not be defined over the whole real line).
    Moreover, the correct solution can be represented by a linear combination of planar waves, which can be

--- a/symplyphysics/laws/relativistic/spacetime_interval.py
+++ b/symplyphysics/laws/relativistic/spacetime_interval.py
@@ -2,7 +2,7 @@
 Spacetime interval via time and distance
 ========================================
 
-The spacetime interval is a combination of distance and time that is invariant under Lorentz tranformations.
+The spacetime interval is a combination of distance and time that is invariant under Lorentz transformations.
 It has the property of being invariant in the sense that it has the same value for all observers in any
 inertial reference frame.
 

--- a/symplyphysics/laws/thermodynamics/internal_energy_via_helmholtz_free_energy.py
+++ b/symplyphysics/laws/thermodynamics/internal_energy_via_helmholtz_free_energy.py
@@ -48,7 +48,7 @@ free_energy = clone_as_function(symbols.helmholtz_free_energy, [temperature, vol
 :symbols:`helmholtz_free_energy` of the system as a function of temperature and volume.
 """
 
-# Volume is held constant during the evalution of the derivative
+# Volume is held constant during the evaluation of the derivative
 
 law = Eq(
     internal_energy,

--- a/symplyphysics/laws/thermodynamics/latent_heat_of_fusion_via_mass.py
+++ b/symplyphysics/laws/thermodynamics/latent_heat_of_fusion_via_mass.py
@@ -2,7 +2,7 @@
 Latent heat of fusion via mass
 ==============================
 
-*Latent heat of fusion* is the heat released into or withdrawn from the enviroment when
+*Latent heat of fusion* is the heat released into or withdrawn from the environment when
 the body changes its state from a solid to a liquid. The same law applies to the process
 of solidification, when the body changes its state from a liquid to a solid, and the
 specific heat of solidification is equal by magnitude to that of fusion.

--- a/symplyphysics/symbols/optics.py
+++ b/symplyphysics/symbols/optics.py
@@ -82,7 +82,7 @@ Optical **magnification** is the ratio between the apparent size in an image and
 
 optical_power = Symbol("D", 1 / units.length)
 """
-**Optical power**, also callled **dioptric power** or **focusing power**, is the degree to which
+**Optical power**, also called **dioptric power** or **focusing power**, is the degree to which
 a lens, mirror, or other optical system converges or diverges light.
 """
 

--- a/symplyphysics/symbols/thermodynamics.py
+++ b/symplyphysics/symbols/thermodynamics.py
@@ -143,7 +143,7 @@ other than thermodynamic work and transfer of matter.
 thermal_efficiency = Symbol("eta", dimensionless, display_latex="\\eta")
 """
 The **thermal efficiency** is a dimensionless performance measure of a device that uses thermal energy. A generic
-definition of thermal energy is the ratio of the energy benefit to the energy costs attributed to the defice.
+definition of thermal energy is the ratio of the energy benefit to the energy costs attributed to the device.
 """
 
 statistical_weight = Symbol("Omega", dimensionless, display_latex="\\Omega")

--- a/test/condensed_matter/equilibrium_voltage_difference_in_pn_junction_via_concentrations_test.py
+++ b/test/condensed_matter/equilibrium_voltage_difference_in_pn_junction_via_concentrations_test.py
@@ -40,7 +40,7 @@ def test_basic_height_barrier(test_args: Args) -> None:
     result = barrier_law.calculate_height_barrier(test_args.donors_concentration,
         test_args.acceptors_concentration, test_args.charge_carriers_concentration,
         test_args.temperature, test_args.charge_electron)
-    # NOTE: onsite intrinsic charge carriers are caclulated instead of hardcoded 1e10 value,
+    # NOTE: onsite intrinsic charge carriers are calculated instead of hardcoded 1e10 value,
     #       therefore result in our test is not very accurate
     assert_equal(result, 0.529 * units.volt, relative_tolerance=0.1)
 

--- a/test/electricity/circuits/admittance_in_parallel_connection_test.py
+++ b/test/electricity/circuits/admittance_in_parallel_connection_test.py
@@ -10,7 +10,7 @@ from symplyphysics.laws.electricity.circuits import admittance_in_parallel_conne
 
 # Description
 ## Assert we have two resistors with 1/2 Siemens and 1/4 Siemens conductance.
-## Accordind to calculator (https://www.chipdip.ru/calc/parallel-resistors) resulting conductance should be 0.75 Siemens.
+## According to calculator (https://www.chipdip.ru/calc/parallel-resistors) resulting conductance should be 0.75 Siemens.
 ## Hence resistors are dipoles, test fixture for parallel resistors law should be suitable for parallel dipoles law as well.
 
 Args = namedtuple("Args", ["S1", "S2"])

--- a/test/electricity/circuits/oscillation_period_of_inductor_capacitor_network_test.py
+++ b/test/electricity/circuits/oscillation_period_of_inductor_capacitor_network_test.py
@@ -10,7 +10,7 @@ from symplyphysics.laws.electricity.circuits import oscillation_period_of_induct
 
 # Description
 ## Assert we have a capacitor with 1 farad capacitance and 1 henry inductor.
-## Accordind to Tomson's formula oscillation period of this circuit should be 6.28 seconds
+## According to Tomson's formula oscillation period of this circuit should be 6.28 seconds
 
 Args = namedtuple("Args", ["L", "C"])
 

--- a/test/electricity/circuits/transmission_lines/impedances_t_type_circuit_of_transmission_line_test.py
+++ b/test/electricity/circuits/transmission_lines/impedances_t_type_circuit_of_transmission_line_test.py
@@ -6,7 +6,7 @@ from symplyphysics import (errors, units, Quantity, assert_equal)
 from symplyphysics.laws.electricity.circuits.transmission_lines import impedances_t_type_circuit_of_transmission_line as impedances_law
 
 ## Characteristic resistance of the transmission line is equal to 50 ohm, line is equal 1 meter,
-## constant propogation is equal 6300 [1 / meter], loss factor is equal to 1.7 [1 / meter].
+## constant propagation is equal 6300 [1 / meter], loss factor is equal to 1.7 [1 / meter].
 ## Then the impedances Z1, Z2, Z3 are equal, respectively: (55.56 - 18.78 * I) ohm,
 ## (55.56 - 18.78 * I) ohm, (-7.59 + 16.21 * I) ohm.
 

--- a/test/electricity/circuits/transmission_lines/input_impedance_lossless_transmission_line_test.py
+++ b/test/electricity/circuits/transmission_lines/input_impedance_lossless_transmission_line_test.py
@@ -6,7 +6,7 @@ from symplyphysics import (errors, units, Quantity, assert_equal)
 from symplyphysics.laws.electricity.circuits.transmission_lines import input_impedance_lossless_transmission_line as impedance_law
 
 ## Characteristic resistance of the transmission line is equal to 50 ohm, line is equal 1 meter,
-## constant propogation is equal 6300 [1 / meter]. Load resistance is equal to 100 ohm.
+## constant propagation is equal 6300 [1 / meter]. Load resistance is equal to 100 ohm.
 ## Then the input impedance is equal to 29.42 - 17.66 * I ohm.
 
 Args = namedtuple("Args",

--- a/test/electricity/circuits/transmission_lines/input_impedance_lossy_transmission_line_test.py
+++ b/test/electricity/circuits/transmission_lines/input_impedance_lossy_transmission_line_test.py
@@ -6,7 +6,7 @@ from symplyphysics import (errors, units, Quantity, assert_equal)
 from symplyphysics.laws.electricity.circuits.transmission_lines import input_impedance_lossy_transmission_line as impedance_law
 
 ## Characteristic resistance of the transmission line is equal to 50 ohm, line is equal 1 meter,
-## constant propogation is equal 6300 [1 / meter], loss factor is equal to 1.7 [1 / meter].
+## constant propagation is equal 6300 [1 / meter], loss factor is equal to 1.7 [1 / meter].
 ## Load resistance is equal to 100 ohm.
 ## Then the input impedance is equal to 49.33 - 0.879 * I ohm.
 

--- a/test/electricity/circuits/transmission_lines/transmission_matrix_lossless_transmission_line_test.py
+++ b/test/electricity/circuits/transmission_lines/transmission_matrix_lossless_transmission_line_test.py
@@ -6,7 +6,7 @@ from symplyphysics import (errors, units, Quantity, assert_equal, prefixes)
 from symplyphysics.laws.electricity.circuits.transmission_lines import transmission_matrix_lossless_transmission_line as matrix_law
 
 ## Characteristic resistance of the transmission line is equal to 50 ohm, line is equal 1 meter,
-## constant propogation is equal 6300 [1 / meter].
+## constant propagation is equal 6300 [1 / meter].
 ## Then the values of A, B, C, D parameters are equal, respectively: -0.4476, -44.7 * I ohm, -17.88 * I millisiemens, -0.4476.
 
 Args = namedtuple("Args", ["characteristic_resistance", "line_length", "constant_propagation"])

--- a/test/electricity/circuits/transmission_lines/transmission_matrix_lossy_transmission_line_test.py
+++ b/test/electricity/circuits/transmission_lines/transmission_matrix_lossy_transmission_line_test.py
@@ -6,7 +6,7 @@ from symplyphysics import (errors, units, Quantity, assert_equal, prefixes)
 from symplyphysics.laws.electricity.circuits.transmission_lines import transmission_matrix_lossy_transmission_line as matrix_law
 
 ## Characteristic resistance of the transmission line is equal to 50 ohm, line is equal 1 meter,
-## constant propogation is equal 6300 [1 / meter], loss factor is equal to 1.7 [1 / meter].
+## constant propagation is equal 6300 [1 / meter], loss factor is equal to 1.7 [1 / meter].
 ## Then the values of A, B, C, D parameters are equal, respectively: -1.265 - 2.365 * I,
 ## -59.2 - 126.5 * I ohm, -23.7 - 50.6 * I millisiemens, -1.265 - 2.365 * I.
 

--- a/test/electricity/power_factor_is_real_power_over_apparent_power_test.py
+++ b/test/electricity/power_factor_is_real_power_over_apparent_power_test.py
@@ -4,7 +4,7 @@ from symplyphysics import (assert_equal, errors, units, Quantity)
 from symplyphysics.laws.electricity import power_factor_is_real_power_over_apparent_power as power_factor_law
 
 # Description
-## Assert we have a device wich consumes 10 Watt of power and makes 3 Watt of work. Power factor of this consumer should be 3/10.
+## Assert we have a device which consumes 10 Watt of power and makes 3 Watt of work. Power factor of this consumer should be 3/10.
 
 Args = namedtuple("Args", ["P", "S"])
 

--- a/test/gravity/gravity_force_from_mass_and_distance_test.py
+++ b/test/gravity/gravity_force_from_mass_and_distance_test.py
@@ -10,7 +10,7 @@ from symplyphysics.laws.gravity import gravity_force_from_mass_and_distance as g
 
 # Description
 ## For example we are calculating gravity force for objects with masses 3000 and 5000 kilograms
-## with 0.06 meters of distance betweem their centers of mass.
+## with 0.06 meters of distance between their centers of mass.
 ## According to matematika-club.ru gravity calculator, force should be equal to 0.27809583 Newtons.
 
 Args = namedtuple("Args", ["m1", "m2", "R"])


### PR DESCRIPTION
## Summary
- correct minor typos in docs and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868356db24483289e93cadc9f7032c3