### PR TITLE
Fix typos in docs

### DIFF
--- a/symplyphysics/core/experimental/vectors/__init__.py
+++ b/symplyphysics/core/experimental/vectors/__init__.py
@@ -157,7 +157,7 @@ def split_factor(value: Any) -> tuple[Expr, Expr]:
 @cacheit
 def into_terms(value: Any) -> tuple[Expr, ...]:
     """
-    Returns a tuple consisting of the terms which, when when added up, would give `value` again.
+    Returns a tuple consisting of the terms which, when added up, would give `value` again.
 
     Raises an error if `value` isn't a vector expression.
     """

--- a/symplyphysics/laws/condensed_matter/current_density_via_number_density_and_drift_velocity.py
+++ b/symplyphysics/laws/condensed_matter/current_density_via_number_density_and_drift_velocity.py
@@ -9,7 +9,7 @@ of the positive charges at this point.
 
 **Conditions:**
 
-#. Charge carriers carry the the same amount of charge.
+#. Charge carriers carry the same amount of charge.
 
 **Links:**
 

--- a/symplyphysics/laws/dynamics/springs/vector/spring_reaction_is_proportional_to_deformation.py
+++ b/symplyphysics/laws/dynamics/springs/vector/spring_reaction_is_proportional_to_deformation.py
@@ -2,7 +2,7 @@
 Spring reaction is proportional to deformation (vector)
 =======================================================
 
-The empirical law known as **Hooke's law** states that that the force needed to extend or compress
+The empirical law known as **Hooke's law** states that the force needed to extend or compress
 a spring by some distance scales linearly with respect to that distance. Also see the :ref:`scalar
 counterpart <Spring reaction is proportional to deformation>` of this law.
 

--- a/symplyphysics/laws/electricity/maxwell_equations/derivative_of_magnetic_induction_in_time_is_rotor_of_electric_intensity.py
+++ b/symplyphysics/laws/electricity/maxwell_equations/derivative_of_magnetic_induction_in_time_is_rotor_of_electric_intensity.py
@@ -48,7 +48,7 @@ Vector of the electric field as a function of :attr:`~position_vector` and :attr
 magnetic_flux_density = clone_as_vector_function(symbols.magnetic_flux_density,
     (position_vector, time))
 """
-Vector of the :symbols:`magnetic_flux_density` field as a function of of :attr:`~position_vector`
+Vector of the :symbols:`magnetic_flux_density` field as a function of :attr:`~position_vector`
 and :attr:`~time`.
 """
 

--- a/symplyphysics/laws/gravity/radial_motion/potential_energy_of_planetary_motion.py
+++ b/symplyphysics/laws/gravity/radial_motion/potential_energy_of_planetary_motion.py
@@ -4,7 +4,7 @@ Potential energy of radial planetary motion
 
 The total mechanical energy of the planet can be viewed as the sum of the kinetic and potential energy.
 The potential energy is in turn the sum of the potential energy due to the gravitational interaction
-between the planet and the Sun, and the the energy of the tangential motion, which depends on the
+between the planet and the Sun, and the energy of the tangential motion, which depends on the
 planet's angular momentum.
 
 **Links:**

--- a/symplyphysics/laws/nuclear/law_of_half_life.py
+++ b/symplyphysics/laws/nuclear/law_of_half_life.py
@@ -3,7 +3,7 @@ Solution to the exponential decay equation
 ==========================================
 
 The solution to the exponential decay equation is the product of the initial quantity
-and the the ratio of the current time to the half-life of the quantity, raised to the
+and the ratio of the current time to the half-life of the quantity, raised to the
 power of 2. In other words, for every half-life that passes, the quantity decays by a
 factor of 2.
 

--- a/symplyphysics/symbols/chemistry.py
+++ b/symplyphysics/symbols/chemistry.py
@@ -23,7 +23,7 @@ entities and the Avogadro constant.
 
 density_of_states = Symbol("D", 1 / units.volume)
 r"""
-The **density of states** of a system describes describes the number of allowed modes or states
+The **density of states** of a system describes the number of allowed modes or states
 per unit energy range.
 """
 

--- a/symplyphysics/symbols/optics.py
+++ b/symplyphysics/symbols/optics.py
@@ -12,7 +12,7 @@ from symplyphysics.core.symbols.symbols import Symbol
 
 relative_refractive_index = Symbol("n", dimensionless)
 """
-**Relative refractive index** of of an optical medium is a dimensionless number that gives the
+**Relative refractive index** of an optical medium is a dimensionless number that gives the
 indication of the light bending ability of that medium. It is defined relative to a certain medium.
 """
 


### PR DESCRIPTION
## Summary
- fix repeated words in documentation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869c00d465c8328ad199e57f40945be